### PR TITLE
process_all: Add support for writing a summary csv file

### DIFF
--- a/bin/process_all
+++ b/bin/process_all
@@ -3,6 +3,9 @@ import sys
 import glob
 import subprocess
 import os
+import json
+import fcntl 
+import numpy as np
 from termcolor import colored
 from joblib import Parallel, delayed
 import multiprocessing
@@ -14,7 +17,26 @@ def parse_num_epochs(num_epochs, granularity=100):
     except ValueError:
         return num_epochs, True
 
-def process_dir(exp_dir):
+def process_result(results_path, out_file, exp_name):
+    with open(results_path, 'r') as f:
+        experiment = json.load(f)['performances']
+
+    model_keys = list(experiment['fair_networks_repr'].keys())
+    fair_results = [experiment['fair_networks_repr'][key] for key in model_keys]
+    random_result = experiment['random_networks_repr'][model_keys[0]]
+    original_results = [experiment['original_repr'][key] for key in model_keys]
+    
+    y_gap = [original_result['y']['val'] - fair_result['y']['val'] for fair_result, original_result in zip(fair_results, original_results)] 
+    s_gap = [np.abs(random_result['s']['val'] - fair_result['s']['val']) for fair_result in fair_results]
+    total_gap = min(y_gap) + min(s_gap)
+
+    with open(out_file, 'a') as f:
+        fcntl.flock(f, fcntl.LOCK_EX)
+        f.write('{},{},{},{}\n'.format(exp_name, min(y_gap), min(s_gap), total_gap))
+        fcntl.flock(f, fcntl.LOCK_UN)
+
+
+def process_dir(exp_dir, out_file):
     model_dir = exp_dir + '/models'
     glob_str = model_dir  + '/*ckpt*'
     ckpt_list = glob.glob(glob_str)
@@ -24,6 +46,7 @@ def process_dir(exp_dir):
     performances_path = exp_dir + '/performances.tsv'
     subprocess.check_output(['touch', all_performances_path])
     config_path = exp_dir + '/config.json'
+    results_path = exp_dir + '/performances.json'
     subprocess.call('bin/random_networks {} -E representations/random_networks_repr'.format(config_path), shell=True)
     subprocess.call('copy_original_representation {} -E representations/original_repr'.format(config_path), shell=True)
 
@@ -36,18 +59,23 @@ def process_dir(exp_dir):
         subprocess.call('fair_networks {} -E representations/fair_networks_repr -i {}'.format(config_path, ckpt),
                         shell=True)
         subprocess.call('test_representations {}'.format(exp_dir), shell=True)
+        process_result(results_path, out_file, exp_dir + '_' + str(num_epochs))
         subprocess.call('process_performances {} > {}'.format(config_path, performances_path), shell=True)
         subprocess.call('printf "Epochs {}" >> {}'.format(num_epochs, all_performances_path), shell=True)
         subprocess.call('cat {} >> {}'.format(performances_path, all_performances_path), shell=True)
         subprocess.call('printf "====\n\n" >> {}'.format(all_performances_path), shell=True)
         subprocess.check_output(['mv', performances_path, 
                                 exp_dir + '/performances{}.tsv'.format(num_epochs)])
-        subprocess.check_output(['mv', exp_dir + '/performances.json', 
-                                exp_dir + 'performances{}.json'.format(num_epochs)])
+        subprocess.check_output(['mv', results_path, 
+                                exp_dir + '/performances{}.json'.format(num_epochs)])
+
+if len(sys.argv) != 3:
+    print('Wrong number of arguments.\nUsage: process_all [experiment_dir] [output_file_path]')
 
 exp_main_dir = sys.argv[1]
+out_file = sys.argv[2]
+subprocess.call('printf "epochs,y_gap,s_gap,total_gap\n" >> {}'.format(out_file), shell=True)
 all_exp_dirs = glob.glob(exp_main_dir + '/*')
 num_cores = 10
 executor = Parallel(n_jobs=num_cores)
-executor(delayed(process_dir)(exp_dir) for exp_dir in all_exp_dirs)
-#subprocess.call('make')
+executor(delayed(process_dir)(exp_dir, out_file) for exp_dir in all_exp_dirs)

--- a/bin/process_performances
+++ b/bin/process_performances
@@ -12,7 +12,12 @@ cwd = os.path.dirname(config_file)
 preference_file = os.path.join(cwd, 'performances.json')
 num_epochs = subprocess.check_output(
     ['fair_networks', config_file, '--get-info=epoch', '--log-level=ERROR'])
-commit_id = subprocess.check_output(['git', 'rev-parse', 'HEAD'], encoding='utf8')
+try:
+    commit_id = subprocess.check_output(['git', 'rev-parse', 'HEAD'], encoding='utf8')
+except TypeError:
+    # python 3.5 support
+    commit_id = subprocess.check_output(['git', 'rev-parse', 'HEAD'])
+
 
 with open(preference_file, "r") as file:
     results = json.load(file)


### PR DESCRIPTION
This commit introduces a way for process_all to write a separate summary csv file with "gap values", i.e. the gap in performance between fair representations, original representations and random representations (the majority class). 

One thing worth mentioning is how to compute the gap across model performances. We have accuracy values taken from experiments involving different models (lr, random forest...).  Currently, the final gap values are the minimum gaps for y and s. 

This makes a lot of sense for y, as we are choosing the model that is closest to the performance on the original representation; I am unsure whether it makes sense for s.